### PR TITLE
fixing overflowing labels

### DIFF
--- a/ampersand-chart.js
+++ b/ampersand-chart.js
@@ -717,6 +717,14 @@
 
             return i % Math.ceil(width / sectionGroupWidth) === 0 ? undefined : 'none';
           }.bind(this))
+          .style('text-anchor', function(d, i) {
+            if (i === 0) {
+              return 'start';
+            } else if (i === containers[0].length - 1) {
+              return 'end';
+            }
+            return 'middle';
+          })
           .transition()
           .style('opacity', 1)
           .attr('x', sectionMargin === 0 ? sectionWidth / 2 : ((sectionWidth * values.length) + sectionMargin * (values.length - 1)) / 2);


### PR DESCRIPTION
This resolves the issue by simply anchoring the first label on the left and the last label on the right. There still may be some cases where it overflows but _best_ solution is far more complex.
