### PR TITLE
Wide "small" value, fixes LC-1302

### DIFF
--- a/ampersand-chart.js
+++ b/ampersand-chart.js
@@ -869,9 +869,11 @@
         })
         .attr('x', function(d) {
           if (d.percent < 10) {
+            this.style.textAnchor = 'start';
             return (this.parentElement.offsetWidth * (d.percent / 100)) + 5 + 'px';
           }
 
+          this.style.textAnchor = 'end';
           return d.percent + '%';
         })
         .style('fill', function(d) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-chart",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Ampersand module for drawing a charts.",
   "main": "ampersand-chart.js",
   "scripts": {


### PR DESCRIPTION
I fixed this by anchoring to the text's `start` for values which appear to the left of the bar. I also added an anchor of `end` for other cases, even though it's already in the CSS I figured it would be good for live charts.
Magic:
![image](https://cloud.githubusercontent.com/assets/2466842/9592444/a2e8d3ac-5008-11e5-9041-9cea1b08c9a2.png)
![image](https://cloud.githubusercontent.com/assets/2466842/9592445/acb30a56-5008-11e5-9fd7-7dfaaabc355e.png)
![image](https://cloud.githubusercontent.com/assets/2466842/9592448/b579fafa-5008-11e5-964b-69da360dc4d8.png)
