### PR TITLE
Add a title attribute for the labels on a count graph.

### DIFF
--- a/ampersand-chart.js
+++ b/ampersand-chart.js
@@ -776,7 +776,7 @@
       var label = this.model.label;
       var minOpacity = this.model.countMinimumOpacity;
       var containerClasses = this.model.countContainerClasses;
-      var max = d3.max(data, function(d) { return d.count; });
+      var max = d3.max(data, _.property('count'));
 
       var containers = this.container.selectAll('div.ampersand-graph-count-container')
         .data(data);
@@ -800,7 +800,7 @@
 
       container.append('div')
         .attr('class', 'ampersand-graph-count-label')
-        .text(function(d) { return d[label]; });
+        .text(_.property(label));
     },
     renderHorizontalBarGraph: function() {
       var data = this.model._data.models;

--- a/ampersand-chart.js
+++ b/ampersand-chart.js
@@ -800,6 +800,7 @@
 
       container.append('div')
         .attr('class', 'ampersand-graph-count-label')
+        .attr('title', _.property(label))
         .text(_.property(label));
     },
     renderHorizontalBarGraph: function() {

--- a/ampersand-chart.js
+++ b/ampersand-chart.js
@@ -784,26 +784,22 @@
       containers.exit()
         .remove();
 
-      var container = containers.enter().append('div')
-        .attr('class', 'ampersand-graph-count-container ' + containerClasses.join(' '));
+      var container = containers.enter().append('div');
 
       container
+        .attr('class', 'ampersand-graph-count-container ' + containerClasses.join(' '))
         .style('opacity', 0)
         .transition()
         .style('opacity', 1);
 
       container.append('div')
-        .attr('class', 'ampersand-graph-count-number');
-
-      containers.select('div.ampersand-graph-count-number')
+        .attr('class', 'ampersand-graph-count-number')
         .text(function(d) { return d.count; })
         .transition()
         .style('opacity', function(d) { return Math.max(d.count / max, minOpacity); });
 
       container.append('div')
-        .attr('class', 'ampersand-graph-count-label');
-
-      containers.select('div.ampersand-graph-count-label')
+        .attr('class', 'ampersand-graph-count-label')
         .text(function(d) { return d[label]; });
     },
     renderHorizontalBarGraph: function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-chart",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Ampersand module for drawing a charts.",
   "main": "ampersand-chart.js",
   "scripts": {


### PR DESCRIPTION
This label is meant to allow the labels in a count graph to be cut off but still provide the user the ability to view the full label via a browser tooltip.
