### PR TITLE
Use any instead of function for prop types.

### DIFF
--- a/ampersand-chart.js
+++ b/ampersand-chart.js
@@ -31,10 +31,10 @@
       searchQueryAttribute: 'string',
 
       // Filter Settings
-      timeRangeFilter: 'function',
-      calendarFilter: 'function',
-      searchSelectFilter: 'function',
-      filterOnApply: [ 'function', false, _.constant(_.noop) ],
+      timeRangeFilter: 'any',
+      calendarFilter: 'any',
+      searchSelectFilter: 'any',
+      filterOnApply: [ 'any', false, _.constant(_.noop) ],
 
       // Filter State
       timeRangeState: 'state',
@@ -60,7 +60,7 @@
       barGroupMarginCoefficient: [ 'number', false, 1.2 ],
       lineGroupMarginCoefficient: [ 'number', false, 2 ],
       areaGroupMarginCoefficient: [ 'number', false, 2 ],
-      circleGraphFunction: 'function',
+      circleGraphFunction: 'any',
       circleGraphLabel: [ 'string', false, '' ],
       colorCount: [ 'number', false, Infinity ],
       valueRoundingPlace: [ 'number', false, 2 ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-chart",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Ampersand module for drawing a charts.",
   "main": "ampersand-chart.js",
   "scripts": {


### PR DESCRIPTION
"function" is not a valid type and has been silently ignored until ampersand-state 4.8.0.  See AmpersandJS/ampersand-state@9e80ea7 for details.
